### PR TITLE
Use download archive instead of directing to one ISO

### DIFF
--- a/html/downloads.html
+++ b/html/downloads.html
@@ -17,17 +17,12 @@
     </div>
     <div id="welcome-text">
         <h1>Virbos downloads</h1>
-        <p>Downloads page for Virbos, a Virbox community linux distribution.</p>
+        <p>Downloads page for Virbos, a Virbox community Linux distribution.</p>
     </div>
     <br>
     <div id="buttons">
-        <button id="download1" onClick="window.location.href='https://download.virbos.xyz/ISOs/virbos-2023.04.30-x86_64.iso'" >Download Virbos</button>
-        <h3>File information</h3>
-        <p>Virbos build: <b>23430</b></p>
-        <p>Filename: virbos-2023.04.30-x86_64.iso</p>
-        <p>SHA-256: 7cb4869b18cfc20b3dcf865fd05d5785642ab4910c49c653e891f618535c99bd</p>
-        <p>Virbos DL: <a href="https://download.virbos.xyz/ISOs">Click here</a></p>
-        <p><b>In the DL you can find previous releases of Virbos</b></p>
+        <button id="download1" onClick="window.location.href='https://download.virbos.xyz/ISOs'" >Download Virbos</button>
+        <p><b>In the download archive you can find previous releases of Virbos and SHA256 sums.</b></p>
     </div>
 </body>
 </html>


### PR DESCRIPTION
We want to direct people to https://download.virbos.xyz/ISOs so we don't need to change all that metadata.